### PR TITLE
custom domains

### DIFF
--- a/apps/tutorials/src/main/java/com/henrikfricke/tutorials/client/EventClient.java
+++ b/apps/tutorials/src/main/java/com/henrikfricke/tutorials/client/EventClient.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.Map;
 
-@FeignClient(value = "EVENTS", path = "/events/api")
+@FeignClient(value = "EVENTS", path = "/api")
 public interface EventClient {
 
     @PostMapping("/events")

--- a/copilot/events/manifest.yml
+++ b/copilot/events/manifest.yml
@@ -12,7 +12,7 @@ http:
   # To match all requests you can use the "/" path.
   path: '/'
   # You can specify a custom health check path. The default is "/".
-  healthcheck: '/'
+  healthcheck: '/actuator/health'
 
 # Configuration for your containers and service.
 image:

--- a/copilot/events/manifest.yml
+++ b/copilot/events/manifest.yml
@@ -10,9 +10,9 @@ type: Load Balanced Web Service
 http:
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.
-  path: 'events'
+  path: '/'
   # You can specify a custom health check path. The default is "/".
-  healthcheck: '/events/'
+  healthcheck: '/'
 
 # Configuration for your containers and service.
 image:
@@ -32,16 +32,14 @@ exec: true     # Enable running commands in your container.
 # Optional fields for more advanced use-cases.
 #
 variables:
- EUREKA_URI: 'http://eureka.${COPILOT_ENVIRONMENT_NAME}.${COPILOT_APPLICATION_NAME}.local:8761/eureka'
- POSTGRES_CLUSTER_SECRET_NAME: EVENTSCLUSTER_SECRET
- SERVER_SERVLET_CONTEXT_PATH: /events
+  EUREKA_URI: 'http://eureka.${COPILOT_ENVIRONMENT_NAME}.${COPILOT_APPLICATION_NAME}.local:8761/eureka'
+  POSTGRES_CLUSTER_SECRET_NAME: EVENTSCLUSTER_SECRET
 
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 
 # You can override any of the values defined above by environment.
-#environments:
-#  test:
-#    count: 2               # Number of tasks to run for the "test" environment.
-#    deployment:            # The deployment strategy for the "test" environment.
-#       rolling: 'recreate' # Stops existing tasks before new ones are started for faster deployments.
+environments:
+  prod:
+    http:
+      alias: events.copilot.superluminar.io

--- a/copilot/tutorials/manifest.yml
+++ b/copilot/tutorials/manifest.yml
@@ -10,9 +10,9 @@ type: Load Balanced Web Service
 http:
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.
-  path: 'tutorials'
+  path: '/'
   # You can specify a custom health check path. The default is "/".
-  healthcheck: '/tutorials/'
+  healthcheck: '/'
 
 # Configuration for your containers and service.
 image:
@@ -34,7 +34,6 @@ exec: true     # Enable running commands in your container.
 variables:                    # Pass environment variables as key value pairs.
  EUREKA_URI: 'http://eureka.${COPILOT_ENVIRONMENT_NAME}.${COPILOT_APPLICATION_NAME}.local:8761/eureka'
  POSTGRES_CLUSTER_SECRET_NAME: TUTORIALSCLUSTER_SECRET
- SERVER_SERVLET_CONTEXT_PATH: /tutorials
 
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
@@ -45,3 +44,8 @@ variables:                    # Pass environment variables as key value pairs.
 #    count: 2               # Number of tasks to run for the "test" environment.
 #    deployment:            # The deployment strategy for the "test" environment.
 #       rolling: 'recreate' # Stops existing tasks before new ones are started for faster deployments.
+
+environments:
+  prod:
+    http:
+      alias: tutorials.copilot.superluminar.io

--- a/copilot/tutorials/manifest.yml
+++ b/copilot/tutorials/manifest.yml
@@ -12,7 +12,7 @@ http:
   # To match all requests you can use the "/" path.
   path: '/'
   # You can specify a custom health check path. The default is "/".
-  healthcheck: '/'
+  healthcheck: '/actuator/health'
 
 # Configuration for your containers and service.
 image:


### PR DESCRIPTION
I created a hosted zone in my playground account and initialized the copilot app with the `--domain` flag. After that, I could deploy the services and get the auto-generated domains (e.g. `tutorials.prod.demo.copilot.superluminar.io`). By setting an alias, I could easily create a production-like domain (in this case `tutorials.copilot.superluminar.io`). Copilot creates a hosted zone per environment so a multi-account setup should be pretty straightforward. Haven't tested it though. 

Documentation: https://aws.github.io/copilot-cli/docs/developing/domain/